### PR TITLE
Add placement group support for low-latency deployments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,9 +53,10 @@ module "cluster" {
   source   = "./modules/cluster"
   for_each = toset(var.regions)
 
-  name         = "${var.name}-${each.key}"
-  cluster_size = var.cluster_size
-  rack_aware   = var.rack_aware
+  name                     = "${var.name}-${each.key}"
+  cluster_size             = var.cluster_size
+  rack_aware               = var.rack_aware
+  placement_group_strategy = var.placement_group_strategy
 
   # Instance configuration
   instance_type    = var.instance_type

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -102,6 +102,18 @@ resource "aws_iam_instance_profile" "redis" {
 }
 
 # -----------------------------------------------------------------------------
+# Placement Group (for low-latency deployments)
+# -----------------------------------------------------------------------------
+
+resource "aws_placement_group" "cluster" {
+  count    = var.placement_group_strategy != "none" ? 1 : 0
+  name     = "${var.name}-placement"
+  strategy = var.placement_group_strategy
+
+  tags = var.tags
+}
+
+# -----------------------------------------------------------------------------
 # Key Pair
 # -----------------------------------------------------------------------------
 
@@ -123,6 +135,7 @@ resource "aws_instance" "master" {
   subnet_id              = local.az_to_subnet[local.node_azs[0]]
   vpc_security_group_ids = [var.security_group_id]
   iam_instance_profile   = aws_iam_instance_profile.redis.name
+  placement_group        = var.placement_group_strategy != "none" ? aws_placement_group.cluster[0].id : null
 
   associate_public_ip_address = !var.private_cluster
 
@@ -173,6 +186,7 @@ resource "aws_instance" "workers" {
   subnet_id              = local.az_to_subnet[local.node_azs[count.index + 1]]
   vpc_security_group_ids = [var.security_group_id]
   iam_instance_profile   = aws_iam_instance_profile.redis.name
+  placement_group        = var.placement_group_strategy != "none" ? aws_placement_group.cluster[0].id : null
 
   associate_public_ip_address = !var.private_cluster
 

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -19,7 +19,7 @@ output "node_private_ips" {
 
 output "node_public_ips" {
   description = "Public IP addresses of all nodes (empty if private cluster)."
-  value       = var.private_cluster ? [] : concat(
+  value = var.private_cluster ? [] : concat(
     [aws_instance.master.public_ip],
     aws_instance.workers[*].public_ip
   )
@@ -43,5 +43,15 @@ output "admin_ui_url" {
 output "key_pair_name" {
   description = "Key pair name for SSH access."
   value       = aws_key_pair.redis.key_name
+}
+
+output "placement_group_name" {
+  description = "Placement group name (null if placement_group_strategy is 'none')."
+  value       = var.placement_group_strategy != "none" ? aws_placement_group.cluster[0].name : null
+}
+
+output "placement_group_id" {
+  description = "Placement group ID (null if placement_group_strategy is 'none')."
+  value       = var.placement_group_strategy != "none" ? aws_placement_group.cluster[0].id : null
 }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -115,3 +115,23 @@ variable "tags" {
   default     = {}
 }
 
+variable "placement_group_strategy" {
+  description = <<-EOT
+    Placement group strategy for cluster nodes. Options:
+    - "none": No placement group (default)
+    - "cluster": All nodes on same rack for lowest latency (~0.1ms)
+    - "spread": Each node on different hardware for max fault tolerance
+    - "partition": Nodes distributed across partitions
+
+    Note: "cluster" strategy provides lowest network latency but reduces
+    fault tolerance (all nodes affected by single rack failure).
+  EOT
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "cluster", "spread", "partition"], var.placement_group_strategy)
+    error_message = "placement_group_strategy must be one of: none, cluster, spread, partition"
+  }
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -127,3 +127,23 @@ output "redis_download_url" {
   value       = local.redis_download_url
 }
 
+# -----------------------------------------------------------------------------
+# Placement Group Information
+# -----------------------------------------------------------------------------
+
+output "placement_group_names" {
+  description = "Placement group names for each region (null if placement_group_strategy is 'none')."
+  value = {
+    for region, cluster in module.cluster :
+    region => cluster.placement_group_name
+  }
+}
+
+output "placement_group_ids" {
+  description = "Placement group IDs for each region (null if placement_group_strategy is 'none')."
+  value = {
+    for region, cluster in module.cluster :
+    region => cluster.placement_group_id
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,27 @@ variable "rack_aware" {
   default     = true
 }
 
+variable "placement_group_strategy" {
+  description = <<-EOT
+    Placement group strategy for cluster nodes. Options:
+    - "none": No placement group (default)
+    - "cluster": All nodes on same rack for lowest latency (~0.1ms vs ~0.5ms)
+    - "spread": Each node on different hardware for max fault tolerance
+    - "partition": Nodes distributed across partitions
+
+    Note: "cluster" strategy provides lowest network latency but reduces
+    fault tolerance (all nodes affected by single rack failure).
+    Typically used with rack_aware = false for latency-sensitive PoCs.
+  EOT
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "cluster", "spread", "partition"], var.placement_group_strategy)
+    error_message = "placement_group_strategy must be one of: none, cluster, spread, partition"
+  }
+}
+
 variable "flash_enabled" {
   description = "Enable Redis on Flash (requires instances with NVMe instance store)."
   type        = bool


### PR DESCRIPTION
## Summary

Add new `placement_group_strategy` variable to control EC2 placement group configuration for cluster nodes.

## Options

- `none`: No placement group (default, backward compatible)
- `cluster`: All nodes on same rack for lowest network latency (~0.1ms vs ~0.5ms)
- `spread`: Each node on different hardware for maximum fault tolerance
- `partition`: Nodes distributed across partitions

## Use Case

The `cluster` strategy is useful for latency-sensitive PoCs where network latency between nodes needs to be minimized. Testing showed:

| Placement | TCP Latency |
|-----------|-------------|
| Same rack (cluster) | ~0.1-0.2ms |
| Different racks (none) | ~0.4-0.6ms |

## Changes

- Add `placement_group_strategy` variable to root and cluster modules
- Create `aws_placement_group` resource when strategy != 'none'
- Assign placement group to master and worker instances
- Add `placement_group_name` and `placement_group_id` outputs

## Usage

```hcl
module "redis_enterprise" {
  source = "github.com/redis-field-engineering/terraform-aws-redis-enterprise"
  
  # ... other config ...
  
  # For lowest latency (PoC/benchmarking)
  rack_aware               = false
  placement_group_strategy = "cluster"
}
```

## Backward Compatibility

Default value is `none`, so existing deployments are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new infrastructure resource creation and ties EC2 instances to a placement group, which can force instance replacement or fail if the chosen strategy conflicts with AZ distribution (e.g., `cluster` with `rack_aware`).
> 
> **Overview**
> Adds a new `placement_group_strategy` input (validated, default `none`) and wires it from the root module into `modules/cluster`.
> 
> When enabled, the cluster module now creates an `aws_placement_group` and assigns it to the master and worker `aws_instance` resources; placement group name/ID are exported both per-cluster and aggregated per-region via new root outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4741952e8ebc74808f8dbf6d51d3cb3b6b565f5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->