### PR TITLE
fix: don't expose redis_license to worker nodes

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -219,7 +219,7 @@ resource "aws_instance" "workers" {
     redis_download_url   = var.redis_download_url
     redis_admin_user     = var.redis_admin_user
     redis_admin_password = var.redis_admin_password
-    redis_license        = var.redis_license
+    redis_license        = "" # License only applied on master node, not exposed to workers
     cluster_fqdn         = var.cluster_fqdn
     flash_enabled        = var.flash_enabled
     node_index           = count.index + 1


### PR DESCRIPTION
The license is only applied on the master node, so passing it to worker nodes unnecessarily expands the attack surface since EC2 user_data is accessible via IMDS.

Addresses Cursor Bugbot feedback on PR #5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Terraform change that only stops propagating the sensitive `redis_license` value to worker EC2 `user_data`; cluster licensing behavior should remain unchanged since licensing is handled on the master node.
> 
> **Overview**
> Stops exposing the Redis Enterprise license string to worker nodes by setting `redis_license` to an empty value in the workers’ `user_data` template invocation.
> 
> The master node continues to receive `var.redis_license`, reducing secret leakage via EC2 instance metadata without changing cluster bootstrap behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1463adeece3451694788ff7137642abf6353afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->